### PR TITLE
Specify system architecture

### DIFF
--- a/home/pinodexmr/setupMenuScripts/setup-tor.sh
+++ b/home/pinodexmr/setupMenuScripts/setup-tor.sh
@@ -10,10 +10,11 @@ sudo apt install apt-transport-https -y
 
 #Establish OS Distribution
 DIST="$(lsb_release -c | awk '{print $2}')"
+ARCH="$(dpkg --print-architecture)"
 
 #Set apt sources to retrieve tor official repository (Print to temp file)
-echo "deb     [signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org $DIST main
-deb-src [signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org $DIST main" > ~/temp_torSources.list
+echo "deb [arch=$ARCH signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org $DIST main
+deb-src [arch=$ARCH signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org $DIST main" > ~/temp_torSources.list
 
 #Overwrite tor.list with new created temp file above.
 sudo mv ~/temp_torSources.list /etc/apt/sources.list.d/tor.list

--- a/home/pinodexmr/setupMenuScripts/setup-tor.sh
+++ b/home/pinodexmr/setupMenuScripts/setup-tor.sh
@@ -20,7 +20,7 @@ deb-src [arch=$ARCH signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https
 sudo mv ~/temp_torSources.list /etc/apt/sources.list.d/tor.list
 
 #add the gpg key used to sign the packages
-sudo wget -qO- https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --dearmor | sudo tee /usr/share/keyrings/tor-archive-keyring.gpg >/dev/null
+wget -qO- https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --dearmor | sudo tee /usr/share/keyrings/tor-archive-keyring.gpg >/dev/null
 
 
 #Install tor and tor debian keyring (keeps signing keys current)


### PR DESCRIPTION
Users report tor key and update error messages regarding incorrect detection of (1) armhf system architecture and (2) key signature update.

Proposed fixes:

(1) Using 'dpkg --print-architecture' rather than fixed setting a fixed "arch=arm64" for amd64 compatibility. The script will determine architecture and input value for dpkg to source correct tor build. Should work for our ARM devices and also AMD64 too. Errors should now more reliable be genuine if 32 bit/i386 device tries to install.

(2) - Closest related fault - https://forum.torproject.org/t/tor-relays-expkeysig-when-running-apt-update/3646 - This error confused me and I'm not at the cause yet. Seems the tor key image error became out of date, despite our usage of tor install manual instructions and gpg key matching at https://support.torproject.org/apt/tor-deb-repo/ 
Anyway, we continue to follow those instructions, we follow both step 3 and 4:

> 3. Then add the gpg key used to sign the packages by running the following command at your command prompt:
>    # wget -qO- https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --dearmor | tee /usr/share/keyrings/deb.torproject.org-keyring.gpg >/dev/null
> 4. Install tor and tor debian keyring
> We provide a Debian package to help you keep our signing key current. It is recommended you use it. Install it with the following commands:
> 
>    # apt update
>    # apt install tor deb.torproject.org-keyring

Only change is we require 'sudo' to tee the entry to /usr/share/keyrings/deb.torproject.org-keyring.gpg