### PR TITLE
P2Pool update failing

### DIFF
--- a/update-p2pool.sh
+++ b/update-p2pool.sh
@@ -48,6 +48,14 @@ if [[ $CPU_ARCH -eq 32 ]]
 		rm -rf /home/pinodexmr/p2pool/
 		echo -e "\e[32mSuccess\e[0m"
 		sleep "2"
+		#Users repot failed P2Pool update (Oct '24) - Fix was missing dependencies update.
+		#Update System and P2Pool Dependences
+		echo -e "\e[32mUpdating dependencies for P2Pool build\e[0m"
+		sleep "2"
+		sudo apt update
+		sudo apt upgrade -y
+		echo -e "\e[32mSuccess\e[0m"
+		sleep "2"
 		echo -e "\e[32mBuilding new P2Pool\e[0m"
 		##Install P2Pool
 		git clone --recursive https://github.com/SChernykh/p2pool 2>&1 | tee -a /home/pinodexmr/debug.log


### PR DESCRIPTION
Outdated system source list and dependencies for new P2Pool build causes P2Pool build fail. System and dependencies update now included in P2Pool update.