### PR TITLE
Use simple config suitable for Ubuntu Server

### DIFF
--- a/etc/apt/sources.list.d/i2p.list
+++ b/etc/apt/sources.list.d/i2p.list
@@ -1,2 +1,0 @@
-deb https://deb.i2p2.de/ buster main
-deb-src https://deb.i2p2.de/ buster main

--- a/home/pinodexmr/setupMenuScripts/setup-i2p.sh
+++ b/home/pinodexmr/setupMenuScripts/setup-i2p.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-##This file created following guidance from https://geti2p.net/en/download/debian#debian
+##This file created following guidance from https://geti2p.net/en/download/debian#ubuntu
 ##Setup i2p dependencies
 echo -e "\e[32mChecking \"apt-transport-https\" and \"curl\" are installed...\e[0m"
 sleep 3
@@ -9,20 +9,13 @@ sleep 3
 ##Setup update location for i2p updates via debian inc keys
 echo -e "\e[32mInstalling I2P...\e[0m"
 sleep 3	
-wget https://raw.githubusercontent.com/shermand100/PiNodeXMR/master/etc/apt/sources.list.d/i2p.list
-sleep 1
-sudo mv /home/pinodexmr/i2p.list /etc/apt/sources.list.d/
-sudo chmod 644 /etc/apt/sources.list.d/i2p.list
-sudo chown root /etc/apt/sources.list.d/i2p.list
-sudo curl -o i2p-debian-repo.key.asc https://geti2p.net/_static/i2p-debian-repo.key.asc
-gpg -n --import --import-options import-show i2p-debian-repo.key.asc
-sudo apt-key add i2p-debian-repo.key.asc
+sudo apt-add-repository ppa:i2p-maintainers/i2p -y
 sudo apt-get update
 
 ##Setup Installing i2p
 echo -e "\e[32mInstalling I2P...\e[0m"
 sleep 3	
-	sudo apt-get install i2p i2p-keyring -y
+	sudo apt-get install i2p -y
 
 
 ##Setup Basic config of i2p
@@ -34,27 +27,6 @@ i2prouter start
 
 sleep 5
 						
-###Make web console accessable on lan
-
-	##If port is random may need to extract I2P web client port. Set as variable to be re-inserted. disabled until needed
-	#WEB_CLIENT_PORT="$(cat /home/pinodexmr/.i2p/clients.config.d/00-net.i2p.router.web.RouterConsoleRunner-clients.config | sed '3q;d' | awk '{ print $1, $4 }' | cut -d'=' -f2-)"
-
-	##Set Device IP variable
-	cd
-	. ~/variables/deviceIp.sh
-	
-	##add lan ip to config (default blocks lan access to web client)
-	#This allows access from ip e.g.: 192.168.1.116:7657
-	sed -i "/clientApp.0.args*/c\clientApp.0.args=7657 ::1,127.0.0.1,"${DEVICE_IP}" ./webapps/" /home/pinodexmr/.i2p/clients.config.d/00-net.i2p.router.web.RouterConsoleRunner-clients.config
-	#This allows access from hostname e.g: http://pinodexmr.local:7657
-	echo "routerconsole.allowedHosts=pinodexmr.local" >> /home/pinodexmr/.i2p/router.config
-
-sleep 2 
-
-i2prouter restart
-
-sleep 5
-	
 whiptail --title "PiNode-XMR I2P" --msgbox "I2P server has been installed and started\n\nYou now have access to the I2P config menu found at $(hostname -I | awk '{print $1}'):7657" 12 78
 
 


### PR DESCRIPTION
Method chosen uses Java based I2P (as opposed to I2Pd C++ method ) due to built in web interface packaged as standard. This keep user interface graphical after terminal based install for simplicity and PiNodeXMR/Monero setup standard as per documented:

https://github.com/shermand100/PiNodeXMR/wiki/i2p-Setup-and-Use